### PR TITLE
#9 Remove priv/crates/<my_nif>/<my_nif>.so before cp

### DIFF
--- a/src/rebar3_cargo_compile.erl
+++ b/src/rebar3_cargo_compile.erl
@@ -122,6 +122,8 @@ cp(Src, DstDir) ->
 
     rebar_api:info("  Copying ~s to ~s...", [Fname, OutPath]),
 
+    file:delete(OutPath),
+
     case file:copy(Src, OutPath) of
         {ok, _} ->
             % Preserve file info


### PR DESCRIPTION
On Apple M1, it seems `file:copy(Src, OutPath)` is not copying over the `.so` file properly, causing the behavior described in #9.

This PR makes it clean up the destination before performing the copy:

```
file:delete(OutPath),
```